### PR TITLE
Add null safe operator for user playcount

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -122,7 +122,7 @@ document.getElementById("run").addEventListener("click", () => {
       artist: lastTrack.recenttracks.track[0].artist["#text"],
       album: lastTrack.recenttracks.track[0].album["#text"],
       trackName: lastTrack.recenttracks.track[0].name,
-      playcount: rData.track.userplaycount ? rData.track.userplaycount : "0",
+      playcount: rData.track?.userplaycount ? rData.track?.userplaycount : "0",
       scrobbles: lastTrack.recenttracks["@attr"].total,
       whenScrobbled: lastTrack.recenttracks.track[0]["@attr"],
       scrobbleStatus: !lastTrack.recenttracks.track[0]["@attr"]

--- a/webpage/js/main.js
+++ b/webpage/js/main.js
@@ -122,7 +122,7 @@ document.getElementById("run").addEventListener("click", () => {
       artist: lastTrack.recenttracks.track[0].artist["#text"],
       album: lastTrack.recenttracks.track[0].album["#text"],
       trackName: lastTrack.recenttracks.track[0].name,
-      playcount: rData.track.userplaycount ? rData.track.userplaycount : "0",
+      playcount: rData.track?.userplaycount ? rData.track?.userplaycount : "0",
       scrobbles: lastTrack.recenttracks["@attr"].total,
       whenScrobbled: lastTrack.recenttracks.track[0]["@attr"],
       scrobbleStatus: !lastTrack.recenttracks.track[0]["@attr"]


### PR DESCRIPTION
When song does't have Scrobbles will give response  "Track not found" to variable `rData`. This case will break the application. So using nullsafe will work in this case.

Testing :
- Song with 0 scrobbler and released on last.fm
![image](https://github.com/PvtTyphoon/lfm-rich-presence/assets/18456011/66ff49c4-9d36-4047-8121-ddc8e7895d24)

- Fetch data for variable `rData`
![image](https://github.com/PvtTyphoon/lfm-rich-presence/assets/18456011/aca0bb88-4484-4b81-afb6-148b304e00d2)

- Error from console 
![image](https://github.com/PvtTyphoon/lfm-rich-presence/assets/18456011/f0b22de4-38ae-4088-9413-14c3d70307ca)

- After add nullsafe operator no error on console and discrod status has updated
![image](https://github.com/PvtTyphoon/lfm-rich-presence/assets/18456011/946ac657-24c5-4c05-a101-8ab5efac8345)

![image](https://github.com/PvtTyphoon/lfm-rich-presence/assets/18456011/13792ca6-83f9-495e-b7fb-bebac66e98d9)

